### PR TITLE
release-1.24: Fix ext_proc tracing sampling

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,8 @@
 name: build
 on:
   push:
-    {}
-    # branches:
-    #   - release-1.24
+    branches:
+      - release-1.24
 
 concurrency: ${{ github.ref }}
 permissions:
@@ -34,4 +33,4 @@ jobs:
           context: .
           platforms: linux/amd64
           push: true
-          tags: getyourguide/proxy:1.24.2-patch.1
+          tags: getyourguide/proxy:1.24.2-patch.${{ github.run_number }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,9 @@
 name: build
 on:
   push:
-    branches:
-      - release-1.24
+    {}
+    # branches:
+    #   - release-1.24
 
 concurrency: ${{ github.ref }}
 permissions:
@@ -33,4 +34,4 @@ jobs:
           context: .
           platforms: linux/amd64
           push: true
-          tags: getyourguide/proxy:1.24.2-patch
+          tags: getyourguide/proxy:1.24.2-patch.1

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,7 +38,10 @@ http_archive(
     sha256 = ENVOY_SHA256,
     strip_prefix = ENVOY_REPO + "-" + ENVOY_SHA,
     url = "https://github.com/" + ENVOY_ORG + "/" + ENVOY_REPO + "/archive/" + ENVOY_SHA + ".tar.gz",
-    patches = ["fix-websocket-handshake.patch"],
+    patches = [
+        "fix-websocket-handshake.patch",
+        "fix-extproc-sampling.patch"
+    ],
     patch_args = ["-p1"],
 )
 

--- a/external/fix-extproc-sampling.patch
+++ b/external/fix-extproc-sampling.patch
@@ -1,0 +1,14 @@
+diff --git a/source/extensions/filters/http/ext_proc/ext_proc.cc b/source/extensions/filters/http/ext_proc/ext_proc.cc
+index 0d35d05425..d1de199068 100644
+--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
++++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
+@@ -416,7 +416,8 @@ Filter::StreamOpenState Filter::openStream() {
+     auto options = Http::AsyncClient::StreamOptions()
+                        .setParentSpan(decoder_callbacks_->activeSpan())
+                        .setParentContext(grpc_context)
+-                       .setBufferBodyForRetry(grpc_service_.has_retry_policy());
++                       .setBufferBodyForRetry(grpc_service_.has_retry_policy())
++                       .setSampled(absl::nullopt);
+ 
+     ExternalProcessorClient* grpc_client = dynamic_cast<ExternalProcessorClient*>(client_.get());
+     ExternalProcessorStreamPtr stream_object =


### PR DESCRIPTION
Disable manual tracing sampling in ext_proc so parent sampling takes precedence.